### PR TITLE
remove un-needed check for current process

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -75,6 +75,8 @@ static NTSTATUS write_to_process(PEPROCESS target_process, PVOID target_address,
 
     NTSTATUS status = STATUS_SUCCESS;
     KAPC_STATE state;
+  
+    KeStackAttachProcess(target_process, &state);
 
     __try
     {


### PR DESCRIPTION
https://github.com/namazso/simplerw_sym/blob/9fe5772260eb8fa015b76528d5a4f154bfdb45d9/main.cpp#L79

there is no need to check if its current process since "KeStackAttachProcess" does it already like this 

IDA decompilation: 

```cpp
  if (CurrentThread->ApcState.Process == Process)
  {
    ApcState->Process = (_KPROCESS*)1;
  }
```

and if its the current process it just sets "ApcState->Process" to 1 and exits the function, ending up not attaching to the process 

Also "KeUnstackDetachProcess" first checks if the "ApcState->Process != (KPROCESS*)1;"

IDA Decompilation: 

```cpp

void __stdcall KeUnstackDetachProcess(PRKAPC_STATE ApcState)
{
  _KPROCESS *Process; // rax

  Process = ApcState->Process;
  if ( Process != (_KPROCESS *)1 )
  {
    if ( !Process )
      ApcState = &KeGetCurrentThread()->SavedApcState;
    KiDetachProcess((struct _KTHREAD *)ApcState, 0);
  }
}
```

if its not equal to 1 (not the current process), it will detach either it just exits the function ending up not detaching. 